### PR TITLE
Support object modules

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ example
 tsconfig.json
 src
 test
+.nyc_output

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lotion-state-machine",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -426,9 +426,9 @@
       }
     },
     "lotion-router": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lotion-router/-/lotion-router-1.0.0.tgz",
-      "integrity": "sha512-pYstIJStXMpRYK1q0H5LbuzX3l1BWqc13wFi9ALGz1J4FDHu2paVbBneT2JwTcbvQoWj5ChwENkYzrU6HfBVgA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lotion-router/-/lotion-router-2.0.0.tgz",
+      "integrity": "sha512-F2mhIn4ljIMf2m5RDd/wspA6kznTNQOWFeCWCCkKUOuMH50hR4mcq6dTUhTj04wAnJqWzkFklj4kEA4Lwa/5PQ==",
       "requires": {
         "old": "^0.2.0"
       }
@@ -1723,6 +1723,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
+      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
       "dev": true
     },
     "wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lotion-state-machine",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lotion-state-machine",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "dist/lotion-state-machine.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lotion-state-machine",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "",
   "main": "dist/lotion-state-machine.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "dist/lotion-state-machine.js",
   "scripts": {
-    "test": "nyc -r text -r html tape test/*.js"
+    "test": "nyc -r text -r html tape test/*.js",
+    "publish": "tsc"
   },
   "keywords": [],
   "author": "",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "nyc": "^13.0.1",
-    "tape": "^4.9.1"
+    "tape": "^4.9.1",
+    "typescript": "^3.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@types/node": "^10.5.2",
     "deterministic-json": "^1.0.5",
-    "lotion-router": "^1.0.0",
+    "lotion-router": "^2.0.0",
     "muta": "^0.4.0"
   },
   "devDependencies": {

--- a/src/lotion-state-machine.ts
+++ b/src/lotion-state-machine.ts
@@ -93,14 +93,14 @@ function LotionStateMachine(opts: BaseApplicationConfig): Application {
         }
       } else {
         // object module
-        if (middleware.txHandler) {
-          appMethods.useTx(middleware.txHandler)
+        if (middleware.transactionHandlers) {
+          middleware.transactionHandlers.forEach((h) => appMethods.useTx(h))
         }
-        if (middleware.blockHandler) {
-          appMethods.useBlock(middleware.blockHandler)
+        if (middleware.blockHandlers) {
+          middleware.blockHandlers.forEach((h) => appMethods.useBlock(h))
         }
-        if (middleware.initializer) {
-          appMethods.useInitializer(middleware.initializer)
+        if (middleware.initializers) {
+          middleware.initializers.forEach((h) => appMethods.useInitializer(h))
         }
       }
       return appMethods

--- a/src/lotion-state-machine.ts
+++ b/src/lotion-state-machine.ts
@@ -80,14 +80,28 @@ function LotionStateMachine(opts: BaseApplicationConfig): Application {
         middleware.forEach(appMethods.use)
       } else if (typeof middleware === 'function') {
         appMethods.useTx(middleware)
-      } else if (middleware.type === 'tx') {
-        appMethods.useTx(middleware.middleware)
-      } else if (middleware.type === 'block') {
-        appMethods.useBlock(middleware.middleware)
-      } else if (middleware.type === 'initializer') {
-        appMethods.useInitializer(middleware.middleware)
+      } else if (middleware.type != null) {
+        // type/middleware object
+        if (middleware.type === 'tx') {
+          appMethods.useTx(middleware.middleware)
+        } else if (middleware.type === 'block') {
+          appMethods.useBlock(middleware.middleware)
+        } else if (middleware.type === 'initializer') {
+          appMethods.useInitializer(middleware.middleware)
+        } else {
+          throw Error('Unknown middleware type')
+        }
       } else {
-        throw Error('Unknown middleware type')
+        // object module
+        if (middleware.txHandler) {
+          appMethods.useTx(middleware.txHandler)
+        }
+        if (middleware.blockHandler) {
+          appMethods.useBlock(middleware.blockHandler)
+        }
+        if (middleware.initializer) {
+          appMethods.useInitializer(middleware.initializer)
+        }
       }
       return appMethods
     },


### PR DESCRIPTION
This PR adds supports for middleware with the new object format, which looks like this:
```js
app.use({
  txHandler: (state, tx, context) { ... },
  blockHandler: (state, context) { ... },
  initializer: (state, context) { ... }
})
```